### PR TITLE
wrong data type for top-level-equipment in FILTERED_CONTROL_CONSTRUCT response schema

### DIFF
--- a/spec/NetworkDataLakeProxy.yaml
+++ b/spec/NetworkDataLakeProxy.yaml
@@ -10839,7 +10839,7 @@ components:
         top-level-equipment:
           type: array
           items:
-            type: object
+            type: string
             additionalProperties: true
         firmware-1-0:firmware-collection:
           type: object


### PR DESCRIPTION
Fixes #36